### PR TITLE
COPYRIGHT: remove leftovers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,7 @@ all-local: $(man_HTML)
 clean-local:
 	rm -f $(man_HTML)
 
-EXTRA_DIST = ChangeLog.html COPYRIGHT rtptools.html bark.rtp \
+EXTRA_DIST = ChangeLog.html rtptools.html bark.rtp \
         nt/*.c nt/include/*.h \
         nt/include/arpa/*.h nt/include/netinet/*.h \
         nt/include/rpcsvc/*.h nt/include/sys/*.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -359,7 +359,7 @@ rtpdump_SOURCES = $(COMMON) rd.c rtpdump.h rtpdump.c
 @DARWIN_TRUE@rtpplay_SOURCES = $(COMMON) rd.c hsearch.c rtpplay.c
 rtpsend_SOURCES = $(COMMON) rtpsend.c
 rtptrans_SOURCES = $(COMMON) rtptrans.c
-EXTRA_DIST = ChangeLog.html COPYRIGHT rtptools.html bark.rtp \
+EXTRA_DIST = ChangeLog.html rtptools.html bark.rtp \
         nt/*.c nt/include/*.h \
         nt/include/arpa/*.h nt/include/netinet/*.h \
         nt/include/rpcsvc/*.h nt/include/sys/*.h \


### PR DESCRIPTION
After removing the `COPYRIGHT` file in the relicensing patch,
I forgot to remove its mentions in the Makefile.