### PR TITLE
README: describe the git build, tweak wording

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,4 +77,4 @@ EXTRA_DIST = ChangeLog.html bark.rtp \
         $(man_MANS) \
         rtptools.dsw rtpdump.dsp rtpplay.dsp rtpsend.dsp rtptrans.dsp \
         bcb/*.bp? bcb/obj/* rtptools.spec rtptools.html.in \
-        bootstrap LICENSE README.md
+        LICENSE README.md

--- a/README.md
+++ b/README.md
@@ -21,44 +21,32 @@ Refer to the individual manpages for details.
 
 ## Installation
 
-The RTP tools should compile on any Posix-compliant platform
-supporting sockets, as well as on Windows.
+The RTP tools should compile on any POSIX-compliant
+platform supporting sockets.
 
 ### UNIX
 
-- Run `./bootstrap; ./configure; make` for compiling after cloning from git.
+- If building from git, run the following first to regenerate the build tools:
 
-- `make install` for installing.
+```
+aclocal
+automake --add-missing --force-missing
+autoconf
+```
 
-- `make uninstall` for uninstalling.
+- Run `./configure` to configure rtptools for your system.
+- Run `make` to build rtptools.
+- Run `make install` to install.
+- Run `make uninstall` to unisntall.
 
-- `make distclean; ./configure; make dist` generates a source tar file
-  `rtptools-*tar.gz`. e.g. rtptools-1.22.tar.gz
-    - It is using autotools and once the tar file have been made,
-      `./configure; make` should works after copying the `rtptools-*tar.gz`
-      to other system, such as, from Linux to OpenBSD and others.
+- Run `make rpm-spec` to create a spec file for a rpm package.
+  Then run `rpmbuild -ba rtptools-*.spec` or `rpmbuild -bb rtptools-*.spec`
+  on your rpm based distribution.
 
-- `make rpm-spec` will create spec file for generating rpm package.
-  Then run `rpmbuild -ba rtptools-*.spec` or
-  `rpmbuild -bb rtptools-*.spec` on rpm based distribution.
-
-- `make html` generates html files from man pages.
-
-
-### Windows (broken at the moment)
-
-The `*.dsp` files are project files. `*.dsw` file and workspace file.
-User can open the workspace file and use 'batch compile'
-to compile all the projects.
-
-* In Visual C++ 6.0, open workspace file rtptools.dsw.
-* In VC menu Build, use Batch Build to build all the tools.
-* All the rtptools will be created under the "debug\" directory.
 
 ## TODO
 
 * Improve generating html for homepage.
-* Fixing type mismatch warnings.
-* Fixing building on windows.
-* Adding file to generate debian package.
-* And any other issues come up.
+* Fix type mismatch warnings.
+* Fix building on windows.
+* Generate a debian package.

--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-aclocal
-automake --add-missing --force-missing
-autoconf


### PR DESCRIPTION
This spells out the instructions to build from git,
removes all mentions of the non-working Windoes build (except TODO),
and tweaks the wording: I believe it is customary to spell the technical
instructions in the imperative, as in `fix type warnings`, not `fixing type warnigns` etc.