### PR TITLE
make html: man2html cannot do it

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,14 +37,10 @@ endif
 if HAVE_MANDOC
 GEN_HTML = mandoc -Thtml
 endif
-if HAVE_MAN2HTML
-GEN_HTML = man2html
-endif
 
 html: $(man_MANS)
 if !FOUND_GEN_HTML
-	@echo "No mandoc, groff or man2html to generate html, skipping."
-	@echo "Please install mandoc, groff or man2html."
+	@echo "No mandoc or groff to generate html, skipping."
 	@exit 1
 endif
 	for MAN_FILE in $(man_MANS) ; do \

--- a/configure.ac
+++ b/configure.ac
@@ -41,16 +41,8 @@ if test x"$FOUND_MANDOC" == x"yes" ; then
 fi
 AM_CONDITIONAL([HAVE_MANDOC], [test x"$WORKS_MANDOC" == x"yes"])
 
-AC_CHECK_PROG([FOUND_MAN2HTML], [man2html], [yes])
-if test x"$FOUND_MAN2HTML" == x"yes" ; then
-  if $(man2html rtpplay.1 > /dev/null 2>&1) ; then
-    WORKS_MAN2HTML="yes"
-  fi
-fi
-AM_CONDITIONAL([HAVE_MAN2HTML], [test x"$WORKS_MAN2HTML" == x"yes"])
-
 AM_CONDITIONAL([FOUND_GEN_HTML], [test x"$WORKS_GROFF" == x"yes"] || 
-  [test x"$WORKS_MANDOC" == x"yes"] || [test x"$WORKS_MAN2HTML" == x"yes"])
+  [test x"$WORKS_MANDOC" == x"yes"])
 
 dnl Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
`man2html` cannot convert the mdoc(7) manpages to html. This was aleady done in
https://github.com/columbia-irt/rtptools/commit/b7784758d045223f6d2e009bf5d9b2975551ccc2