### PR TITLE
socklen_t where appropriate

### DIFF
--- a/rtpdump.c
+++ b/rtpdump.c
@@ -833,7 +833,7 @@ int main(int argc, char *argv[])
       }
       for (i = 0; i < 2; i++) {
         if (sock[i] >= 0 && FD_ISSET(sock[i], &readfds)) {
-          int alen = sizeof(sin);
+          socklen_t alen = sizeof(sin);
 
           /* subtract elapsed time from remaining timeout */
           gettimeofday(&now, 0);

--- a/rtptrans.c
+++ b/rtptrans.c
@@ -186,9 +186,10 @@ struct sdes_msg {
 */
 static Notify_value socket_handler(Notify_client client, int sock)
 {
-  int len, addr_len;
+  int len;
   int proto;
   struct sockaddr_in sin_from;
+  socklen_t addr_len;
   char packet[8192];
   int i;
   const int VAT_LEN=8;


### PR DESCRIPTION
`recvfrom()` in rtpdump and rtptrans takes a `socklen_t` argument, not an int.
Fixes a type warning on OpenBSD 6.2, MacOS 10.13.2, Debian 7.11, Solaris 11.3