### PR TITLE
__sun identifies SunOS (and its struct msghdr)

### DIFF
--- a/rtptrans.c
+++ b/rtptrans.c
@@ -310,12 +310,12 @@ static Notify_value socket_handler(Notify_client client, int sock)
         if (side[i][proto].sock != sock) {
           msg.msg_name = (caddr_t ) &side[i][proto].sin;
           msg.msg_namelen = sizeof(side[i][proto].sin);
-#if defined(__unix__) || defined(__FreeBSD__) || defined(__linux__) || defined(__darwin__) /* Or presumably other BSD 4.4 systems */
-          msg.msg_control = 0;
-          msg.msg_controllen = 0;
-#else
+#if defined(__sun)
           msg.msg_accrights = 0;
           msg.msg_accrightslen = 0;
+#else
+          msg.msg_control = 0;
+          msg.msg_controllen = 0;
 #endif
           if ((sendmsg(side[i][2].sock, &msg,0))!= 
             iov[0].iov_len +iov[1].iov_len)


### PR DESCRIPTION
This makes the distinctin between SunOS's `struct msghdr` and the other UNIXes,
making `rtptrans.c` compile on Solaris 11.3, while not breaking it on OpenBSD 6.2,
MacOS 10.13.2, Debian 7.11