### PR TITLE
random: we only need a random seq number

### DIFF
--- a/ansi.h
+++ b/ansi.h
@@ -90,8 +90,6 @@ extern void perror(char *s);
 extern int qsort(void *base, long unsigned nel, long unsigned int
   width, int (*compar)(const void *, const void *));
 extern long strtol(char *str, char **ptr, int base);
-extern double drand48(void);
-extern void srand48(long seedval);
 extern int atoi(const char *str);
 extern int system(char *cmd);
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ AC_TYPE_SIGNAL
 AC_FUNC_STRFTIME
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS(gethostbyname gettimeofday mktime select \
-        strdup strerror strstr strtol uname srand48)
+        strdup strerror strstr strtol uname srand)
 
 dnl Checks for libraries.
 

--- a/rtptrans.c
+++ b/rtptrans.c
@@ -106,11 +106,6 @@ int create_stream(int addr, int next)
     head=new_stream;
     middle=new_stream;
     list_len=1;
-#ifdef HAVE_SRAND48
-    srand48(rand());  /* initialize random number generator */
-#else
-    srand(rand());    /* (fred) This is surprising */
-#endif
     new_stream->seq=rand();
     last=new_stream;
     return new_stream->seq;
@@ -410,6 +405,8 @@ int main(int argc, char *argv[])
   int i, j;
 
   extern struct in_addr host2ip(char *);
+
+  srand(0); /* Only needed for random seq numbers */
 
   /* Set up socket. */
   startupSocket();

--- a/rtptrans.c
+++ b/rtptrans.c
@@ -406,8 +406,6 @@ int main(int argc, char *argv[])
 
   extern struct in_addr host2ip(char *);
 
-  srand(0); /* Only needed for random seq numbers */
-
   /* Set up socket. */
   startupSocket();
   while ((c = getopt(argc, argv, "d?h")) != EOF) {


### PR DESCRIPTION
There is no point in prefering srand48() over srand(),
let alone srand(rand()) and such. We only need a seq number.