### PR TITLE
Add Travis CI build automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: trusty
+sudo: false
+
+language: c
+
+script:
+  - ./configure
+  - make
+  - make distcheck


### PR DESCRIPTION
Travis is a free Continuous Integration tool that can help verify that builds succeed.
It integrates well with GitHub and can build Branches and Pull Requests automatically.

This configuration only tests Linux at the moment, but it is also possible to test on Mac OS.

There is an example build output here:
https://travis-ci.org/njh/rtptools/builds/357767378
