### PR TITLE
build and link the compat-* files properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,12 @@ HAVE_SRCS = \
 	have-msgcontrol.c
 
 COMPAT_SRCS = \
-	compat_err.c		\
-	compat_strtonum.c
+	compat-err.c		\
+	compat-strtonum.c
 
 COMPAT_OBJS = \
-	compat_err.o		\
-	compat_strtonum.o
+	compat-err.o		\
+	compat-strtonum.o
 
 OBJS =	$(rtpdump_OBJS) $(rtpplay_OBJS) $(rtpsend_OBJS) $(rtptrans_OBJS)
 OBJS +=	$(COMPAT_OBJS)
@@ -141,17 +141,17 @@ Makefile.local config.h: configure $(HAVESRCS)
 	@echo "$@ is out of date; please run ./configure"
 	@exit 1
 
-rtpdump: $(rtpdump_OBJS)
-	$(CC) $(CFLAGS) -o rtpdump $(rtpdump_OBJS) $(LDADD)
+rtpdump: $(rtpdump_OBJS) $(COMPAT_OBJS)
+	$(CC) $(CFLAGS) -o rtpdump $(rtpdump_OBJS) $(COMPAT_OBJS) $(LDADD)
 
-rtpplay: $(rtpplay_OBJS)
-	$(CC) $(CFLAGS) -o rtpplay $(rtpplay_OBJS) $(LDADD)
+rtpplay: $(rtpplay_OBJS) $(COMPAT_OBJS)
+	$(CC) $(CFLAGS) -o rtpplay $(rtpplay_OBJS) $(COMPAT_OBJS) $(LDADD)
 
-rtpsend: $(rtpsend_OBJS)
-	$(CC) $(CFLAGS) -o rtpsend $(rtpsend_OBJS) $(LDADD)
+rtpsend: $(rtpsend_OBJS) $(COMPAT_OBJS)
+	$(CC) $(CFLAGS) -o rtpsend $(rtpsend_OBJS) $(COMPAT_OBJS) $(LDADD)
 
-rtptrans: $(rtptrans_OBJS)
-	$(CC) $(CFLAGS) -o rtptrans $(rtptrans_OBJS) $(LDADD)
+rtptrans: $(rtptrans_OBJS) $(COMPAT_OBJS)
+	$(CC) $(CFLAGS) -o rtptrans $(rtptrans_OBJS) $(COMPAT_OBJS) $(LDADD)
 
 $(EMPTY):
 	mkdir -p win/include/{arpa,netinet,sys}

--- a/Makefile.depend
+++ b/Makefile.depend
@@ -4,7 +4,11 @@ hsearch.o: hsearch.c sysdep.h hsearch.h
 multimer.o: multimer.c multimer.h notify.h sysdep.h
 notify.o: notify.c sysdep.h notify.h multimer.h ansi.h
 rd.o: rd.c rtpdump.h sysdep.h
+
 rtpdump.o: rtpdump.c rtp.h sysdep.h vat.h rtpdump.h ansi.h
 rtpplay.o: rtpplay.c sysdep.h notify.h rtp.h rtpdump.h multimer.h ansi.h
 rtpsend.o: rtpsend.c notify.h rtp.h sysdep.h multimer.h ansi.h
 rtptrans.o: rtptrans.c rtp.h sysdep.h rtpdump.h ansi.h notify.h multimer.h vat.h
+
+compat-err.o: compat-err.c
+compat-strtonum.o: compat-strtonum.c


### PR DESCRIPTION
next step: do actually use `err(3)` and `strtonum(3)` where appropriate.