### PR TITLE
Added matrix to Travis CI to build multiple OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
-dist: trusty
+language: c
 sudo: false
 
-language: c
+matrix:
+    include:
+        - os: linux
+          dist: trusty
+          env: OS=Ubuntu14.04
+        - os: linux
+          dist: precise
+          env: OS=Ubuntu12.04
+        - os: osx
+          env: OS=MacOS
 
 script:
   - ./configure


### PR DESCRIPTION
Added matrix to Travis CI to build against three different OSes:
* Mac OS
* Ubuntu 12.04 (Precise Pangolin)
* Ubuntu 14.04 (Trusty Tahr)

Note that Mac OS is failing due to problem with a macro - see #76

Example build output from my own Github fork here:
https://travis-ci.org/njh/rtptools/builds/360074401
