### PR TITLE
cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,14 +177,3 @@ distcheck: dist
 .1.1.html:
 	{ which mandoc > /dev/null && mandoc -Thtml -Wstyle $< > $@ ; } || \
 	{ which groff  > /dev/null && groff  -Thtml -mdoc   $< > $@ ; }
-
-# The rest of this file is the relevant portions of old Makefile.am
-# that we need go through to make sure nothing is left behind
-
-#if DARWIN #rtpplay_SOURCES = $(COMMON) rd.c hsearch.c rtpplay.c
-
-#rpm: $(bin_PROGRAMS) rtptools.spec dist
-#mkdir -p ./rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-#cp rtptools-$(VERSION).tar.gz ./rpmbuild/SOURCES/.
-#sed s/VERSION/$(VERSION)/g  rtptools.spec > ./rpmbuild/SPECS/rtptools-$(VERSION).spec
-#rpmbuild --define "_topdir `pwd`/rpmbuild" -ba rpmbuild/SPECS/rtptools-$(VERSION).spec

--- a/configure
+++ b/configure
@@ -274,9 +274,3 @@ echo "Makefile.local: written" 1>&2
 echo "Makefile.local: written" 1>&3
 
 exit 0
-
-# FIXME These are the leftovers of the old configure.ac: anything left behind?
-
-#AC_FUNC_STRFTIME
-#AC_FUNC_VPRINTF
-#AC_CHECK_FUNCS(gettimeofday strerror strstr strtol)


### PR DESCRIPTION
This deletes the comments from the old build system.
The functions exist everywhere, or we hve a replacement,
or we never use them in the first place.

RPM has its own issue open.

No functional change