### PR TITLE
simplify hpt()

### DIFF
--- a/hpt.c
+++ b/hpt.c
@@ -44,10 +44,9 @@ extern struct in_addr host2ip(char *);
 
 /* Parse [host]/port[/ttl]. Return 0 if ok, -1 on error;
  * set sockaddr and ttl value. */
-int hpt(char *h, struct sockaddr *sa, unsigned char *ttl)
+int hpt(char *h, struct sockaddr_in *sin, unsigned char *ttl)
 {
   char *s;
-  struct sockaddr_in *sin = (struct sockaddr_in *)sa;
 
   sin->sin_family = AF_INET;
 

--- a/rtpdump.c
+++ b/rtpdump.c
@@ -54,6 +54,8 @@
 
 #define RTPFILE_VERSION "1.0"
 
+extern int hpt(char*, struct sockaddr_in*, unsigned char*);
+
 typedef uint32_t member_t;
 
 static int verbose = 0; /* decode */
@@ -161,9 +163,8 @@ static int open_network(char *host, int data, int sock[], struct
   struct ip_mreq mreq;      /* multicast group */
   int i;
   int nfds = 0;
-  extern int hpt(char *h, struct sockaddr *sa, unsigned char *ttl);
 
-  if (hpt(host, (struct sockaddr *)sin, 0) < 0) {
+  if (hpt(host, sin, 0) == -1) {
     usage("");
     exit(1);
   }

--- a/rtpplay.c
+++ b/rtpplay.c
@@ -59,6 +59,8 @@
 
 #define READAHEAD 16 /* must be power of 2 */
 
+extern int hpt(char*, struct sockaddr_in*, unsigned char*);
+
 static int verbose = 0;        /* be chatty about packets sent */
 static int wallclock = 0;      /* use wallclock time rather than timestamps */
 static uint32_t begin = 0;      /* time of first packet to send */
@@ -312,7 +314,6 @@ int main(int argc, char *argv[])
   int c;
   extern char *optarg;
   extern int optind;
-  extern int hpt(char *h, struct sockaddr *sa, unsigned char *ttl);
 
   /* For NT, we need to start the socket; dummy function otherwise */
   startupSocket();
@@ -356,7 +357,7 @@ int main(int argc, char *argv[])
 //  ftell(in);
 
   if (optind < argc) {
-    if (hpt(argv[optind], (struct sockaddr *)&sin, &ttl) < 0) {
+    if (hpt(argv[optind], &sin, &ttl) == -1) {
       usage(argv[0]);
       exit(1);
     }

--- a/rtpsend.c
+++ b/rtpsend.c
@@ -49,11 +49,12 @@
 #include "multimer.h"
 #include "sysdep.h"
 
+extern int hpt(char*, struct sockaddr_in*, unsigned char*);
+
 static int verbose = 0;
 static FILE *in;
 static int sock[2];  /* output sockets */
 static int loop = 0; /* play file indefinitely if set */
-
 
 /*
 * Node either has a parameter or a non-zero pointer to list.
@@ -876,7 +877,6 @@ int main(int argc, char *argv[])
   char *filename = 0;
   extern char *optarg;
   extern int optind;
-  extern int hpt(char *h, struct sockaddr *sa, unsigned char *ttl);
 
   /* parse command line arguments */
   startupSocket();
@@ -917,7 +917,7 @@ int main(int argc, char *argv[])
   }
 
   if (optind < argc) {
-    if (hpt(argv[optind], (struct sockaddr *)&sin, &ttl) < 0) {
+    if (hpt(argv[optind], &sin, &ttl) == -1) {
       usage(argv[0]);
       exit(1);
     }


### PR DESCRIPTION
everyone passes sockaddr to hpt(), which converts to sockadr_in;
so pass sockadr_in instead. Also, it returns -1 on error.