### PR TITLE
windows does not have err()

### DIFF
--- a/sysdep.h
+++ b/sysdep.h
@@ -33,13 +33,13 @@
 
 #if defined(WIN32) || defined(__WIN32__)
 
-#include <winsock2.h>  /* For NT socket */
-#include <ws2tcpip.h>  /* IP_ADD_MEMBERSHIP */
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
-#include <stdio.h>     /* stderr */
-#include <time.h>      /* time_t */
+#include <stdio.h>
+#include <time.h>
 
-#define HAVE_STDINT_H 1
+#define HAVE_ERR 0
 #define RTP_BIG_ENDIAN 0
 
 /* Determine if the C(++) compiler requires complete function prototype  */

--- a/utils.c
+++ b/utils.c
@@ -31,13 +31,13 @@
 #include <sys/types.h>
 #include <stdlib.h>
 #include <string.h>
-#include <err.h>
 
 #ifndef WIN32
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <err.h>
 #endif
 
 #include "sysdep.h"

--- a/win/rtpdump.vcxproj
+++ b/win/rtpdump.vcxproj
@@ -87,6 +87,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="../utils.c" />
+    <ClCompile Include="../compat-err.c" />
     <ClCompile Include="../multimer.c" />
     <ClCompile Include="../notify.c" />
     <ClCompile Include="../rd.c" />

--- a/win/rtpplay.vcxproj
+++ b/win/rtpplay.vcxproj
@@ -89,6 +89,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="../utils.c" />
+    <ClCompile Include="../compat-err.c" />
     <ClCompile Include="../compat-hsearch.c" />
     <ClCompile Include="../multimer.c" />
     <ClCompile Include="../notify.c" />

--- a/win/rtpsend.vcxproj
+++ b/win/rtpsend.vcxproj
@@ -89,6 +89,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="../utils.c" />
+    <ClCompile Include="../compat-err.c" />
     <ClCompile Include="../multimer.c" />
     <ClCompile Include="../notify.c" />
     <ClCompile Include="../rtpsend.c" />

--- a/win/rtptrans.vcxproj
+++ b/win/rtptrans.vcxproj
@@ -89,6 +89,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="../utils.c" />
+    <ClCompile Include="../compat-err.c" />
     <ClCompile Include="../multimer.c" />
     <ClCompile Include="../notify.c" />
     <ClCompile Include="../rtptrans.c" />


### PR DESCRIPTION
How many straight fixes are gonna be stopped by "windows can't do it"
before we finally drop windows support?

The `./configure` script checks whether the system has `err()` et al.,
and if not, it provides the `compat-err.c` implementation.
But windows cannot run `./configure` of course,
so we don't have the resulting `config.h` file on windows.

So hardcode `HAVE_ERR 0` in the windows section of `sysdep.h`
and only include `err.h` if not on windows.

This fixes https://github.com/columbia-irt/rtptools/issues/98 - can windows users please test?