### PR TITLE
drop unused macros

### DIFF
--- a/sysdep.h
+++ b/sysdep.h
@@ -67,18 +67,6 @@
 #define timeb _timeb
 #endif /* _MSC_VER */
 
-#ifndef SIGBUS
-#define SIGBUS SIGINT
-#endif
-
-#ifndef SIGHUP
-#define SIGHUP SIGINT
-#endif
-
-#ifndef SIGPIPE
-#define SIGPIPE SIGINT
-#endif
-
 #ifndef EADDRNOTAVAIL
 #define EADDRNOTAVAIL WSAEADDRNOTAVAIL
 #endif
@@ -92,12 +80,6 @@ typedef UINT32 uid_t;
 
 typedef char *   caddr_t;        /* core address */
 typedef long  fd_mask;
-#define NBBY  8   /* number of bits in a byte */
-#define NFDBITS (sizeof(fd_mask) * NBBY)  /* bits per mask */
-
-#ifndef howmany
-#define howmany(x, y) (((x) + ((y) - 1)) / (y))
-#endif
 
 struct iovec {
     void  *iov_base;    /* Starting address */
@@ -182,10 +164,6 @@ struct  itimerval {
 
 #ifndef ETIME
 #define ETIME 1
-#endif
-
-#ifndef SIGKILL
-#define SIGKILL SIGTERM
 #endif
 
 #define fork() 0

--- a/win/gettimeofday.c
+++ b/win/gettimeofday.c
@@ -79,5 +79,3 @@ int gettimeofday(struct timeval *tv, void *t)
   return 0;
 }
 #endif /* WIN32 */
-
- 

--- a/win/gettimeofday.c
+++ b/win/gettimeofday.c
@@ -66,10 +66,10 @@ int gettimeofday(struct timeval *tv, void *t)
 
   if (!QueryPerformanceCounter(&count))
     return -1;
-  c = count.QuadPart;
-  tv->tv_sec  = stv.tv_sec  + (long)((c - sct) / tick);
-  tv->tv_usec = stv.tv_usec + (long)(((c - sct) % tick) * 1000000 / tick);
-  if (tv->tv_usec >= 1000000) {
+    c = count.QuadPart;
+    tv->tv_sec  = stv.tv_sec  + (long)((c - sct) / tick);
+    tv->tv_usec = stv.tv_usec + (long)(((c - sct) % tick) * 1000000 / tick);
+    if (tv->tv_usec >= 1000000) {
     tv->tv_sec++;
     tv->tv_usec -= 1000000;
   }


### PR DESCRIPTION
These macros don't seem to occur anywehere, can they be dropped?