### PR TITLE
only include config.h if we have it

### DIFF
--- a/compat-err.c
+++ b/compat-err.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "sysdep.h"
 
 #if HAVE_ERR
 

--- a/compat-progname.c
+++ b/compat-progname.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "sysdep.h"
 
 #if HAVE_PROGNAME
 

--- a/compat-strtonum.c
+++ b/compat-strtonum.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "sysdep.h"
 
 #if HAVE_STRTONUM
 

--- a/rtptrans.c
+++ b/rtptrans.c
@@ -41,15 +41,15 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include "config.h"
 #endif
+
+#include "sysdep.h"
 
 #include "rtp.h"
 #include "rtpdump.h"
 #include "notify.h"
 #include "multimer.h"
 #include "vat.h"
-#include "sysdep.h"
 
 extern int hpt(char*, struct sockaddr_in*, unsigned char*);
 

--- a/sysdep.h
+++ b/sysdep.h
@@ -31,16 +31,28 @@
 #ifndef SYSDEP_H
 #define SYSDEP_H
 
+/* In this file, we basically decide whether we are on Windows or not.
+ * On Windows, define a bunch of stuff that Windows needs defined
+ * (TODO: it could probably be cleand up a bit); otherwise,
+ * simply include the config.h produced by configure. */
+
 #if defined(WIN32) || defined(__WIN32__)
+
+#define HAVE_ERR	0
+#define HAVE_HSEARCH	0
+#define HAVE_PROGNAME	0
+#define HAVE_STRTONUM	0
+#define HAVE_LNSL	0
+#define HAVE_LSOCKET	0
+#define HAVE_BIGENDIAN	0
+#define HAVE_MSGCONTROL	0
+#define RTP_BIG_ENDIAN	0
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>
 #include <stdio.h>
 #include <time.h>
-
-#define HAVE_ERR 0
-#define RTP_BIG_ENDIAN 0
 
 /* Determine if the C(++) compiler requires complete function prototype  */
 #ifndef __P
@@ -209,13 +221,13 @@ extern int sendmsg(int s, const struct msghdr *msg, int flags);
 
 #else /* not WIN32 */
 
-/* Windows needs to call this function on <winsock2.h>.
- Otherwise the first call of socket() will fail
- "sock[i] = socket(PF_INET, SOCK_DGRAM, 0);"
- with "socket: No error". Tried on Win10. */
-#ifndef startupSocket
+#include "config.h"
+
+/* Windows needs to call this function as the first thing
+ * to iit its sockat stack as described in <winsock2.h>.
+ * Use it uniformly in the code, but define it away if
+ * we are not on Windows. */
 #define startupSocket()
-#endif
 
 #endif
 

--- a/win/gettimeofday.c
+++ b/win/gettimeofday.c
@@ -79,5 +79,3 @@ int gettimeofday(struct timeval *tv, void *t)
   return 0;
 }
 #endif /* WIN32 */
-
- 

--- a/win/gettimeofday.c
+++ b/win/gettimeofday.c
@@ -66,10 +66,10 @@ int gettimeofday(struct timeval *tv, void *t)
 
   if (!QueryPerformanceCounter(&count))
     return -1;
-  c = count.QuadPart;
-  tv->tv_sec  = stv.tv_sec  + (long)((c - sct) / tick);
-  tv->tv_usec = stv.tv_usec + (long)(((c - sct) % tick) * 1000000 / tick);
-  if (tv->tv_usec >= 1000000) {
+    c = count.QuadPart;
+    tv->tv_sec  = stv.tv_sec  + (long)((c - sct) / tick);
+    tv->tv_usec = stv.tv_usec + (long)(((c - sct) % tick) * 1000000 / tick);
+    if (tv->tv_usec >= 1000000) {
     tv->tv_sec++;
     tv->tv_usec -= 1000000;
   }


### PR DESCRIPTION
The problem this solves is that Windows cannot even run ./configure,
so config.h will not exist, so we cannot include it in source files
that we want to compile on windows. Instead, include sysdep.h
(which always exists), and conditionally include config.h there.

Tested on OpenBSD 6.3, MacOS 10.13.4, Debian 7.11, Gentoo 2.4.1;
please test on Windows.

(Sorry for including the older tweaks in the branch, but they do no harm.)
