### PR TITLE
compat: mangle names to avoid multiple definitions

### DIFF
--- a/compat-err.c
+++ b/compat-err.c
@@ -2,7 +2,7 @@
 
 #if HAVE_ERR
 
-int dummy;
+int dummy_compat_err;
 
 #else
 

--- a/compat-getopt.c
+++ b/compat-getopt.c
@@ -2,7 +2,7 @@
 
 #if HAVE_GETOPT
 
-int dummy;
+int dummy_compat_getopt;
 
 #else
 

--- a/compat-gettimeofday.c
+++ b/compat-gettimeofday.c
@@ -2,7 +2,7 @@
 
 #if HAVE_GETTIMEOFDAY
 
-int dummy;
+int dummy_compat_gettimeofday;
 
 #else
 

--- a/compat-progname.c
+++ b/compat-progname.c
@@ -2,7 +2,7 @@
 
 #if HAVE_PROGNAME
 
-int dummy;
+int dummy_compat_progname;
 
 #else
 

--- a/compat-strtonum.c
+++ b/compat-strtonum.c
@@ -2,7 +2,7 @@
 
 #if HAVE_STRTONUM
 
-int dummy;
+int dummy_compat_strtonum;
 
 #else
 


### PR DESCRIPTION
This was breaking the build (using cc (Ubuntu 11.2.0-19ubuntu1) 11.2.0)